### PR TITLE
Merchant Relationship Endpoints

### DIFF
--- a/app/controllers/api/v1/merchants/invoices_controller.rb
+++ b/app/controllers/api/v1/merchants/invoices_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::InvoicesController < ApplicationController
+  def index
+    render json: InvoiceSerializer.new(Merchant.find(params[:id]).invoices)
+  end
+end

--- a/app/controllers/api/v1/merchants/items_controller.rb
+++ b/app/controllers/api/v1/merchants/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::ItemsController < ApplicationController
+  def index  
+    render json: ItemSerializer.new(Merchant.find(params[:id]).items)
+  end
+end

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,6 +1,8 @@
 class InvoiceSerializer
   include FastJsonapi::ObjectSerializer
 
+  belongs_to :merchant
+
   attributes :id,
              :status,
              :customer_id,

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,6 +1,8 @@
 class ItemSerializer
   include FastJsonapi::ObjectSerializer
 
+  belongs_to :merchant
+
   attributes :id,
              :name,
              :unit_price,

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -2,6 +2,7 @@ class MerchantSerializer
   include FastJsonapi::ObjectSerializer
 
   has_many :items
+  has_many :invoices
 
   attributes :id,
              :name

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,6 +1,8 @@
 class MerchantSerializer
   include FastJsonapi::ObjectSerializer
 
+  has_many :items
+
   attributes :id,
              :name
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
         get "/most_revenue", to: "most_revenue#index"
 
         get "/:id/items", to: "items#index"
-        get "/:id/invoices", to: "items#index"
+        get "/:id/invoices", to: "invoices#index"
       end
 
       resources :items, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
         get "/revenue", to: "total_revenue#index"
         get "/most_items", to: "most_items#index"
         get "/most_revenue", to: "most_revenue#index"
+
+        get "/:id/items", to: "items#index"
+        get "/:id/invoices", to: "items#index"
       end
 
       resources :items, only: [:index, :show]

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -42,4 +42,22 @@ RSpec.describe "Merchants API" do
     expect(merchant_items[1]["id"].to_i).to eq(item_2.id)
     expect(merchant_items[2]["id"].to_i).to eq(item_3.id)
   end
+
+  it "delivers a all invoices for a single Merchant" do
+    merchant = create(:merchant)
+
+    invoice_1 = create(:invoice, merchant: merchant)
+    invoice_2 = create(:invoice, merchant: merchant)
+    invoice_3 = create(:invoice, merchant: merchant)
+
+    get "/api/v1/merchants/#{merchant.id}/invoices"
+    
+    expect(response).to be_successful
+
+    merchant_invoices = JSON.parse(response.body)["data"]
+
+    expect(merchant_invoices[0]["id"].to_i).to eq(invoice_1.id)
+    expect(merchant_invoices[1]["id"].to_i).to eq(invoice_2.id)
+    expect(merchant_invoices[2]["id"].to_i).to eq(invoice_3.id)
+  end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -24,4 +24,22 @@ RSpec.describe "Merchants API" do
 
     expect(merchant["id"].to_i).to eq(id)
   end
+
+  it "delivers a all items for a single Merchant" do
+    merchant = create(:merchant)
+
+    item_1 = create(:item, merchant: merchant)
+    item_2 = create(:item, merchant: merchant)
+    item_3 = create(:item, merchant: merchant)
+
+    get "/api/v1/merchants/#{merchant.id}/items"
+
+    expect(response).to be_successful
+
+    merchant_items = JSON.parse(response.body)["data"]
+
+    expect(merchant_items[0]["id"].to_i).to eq(item_1.id)
+    expect(merchant_items[1]["id"].to_i).to eq(item_2.id)
+    expect(merchant_items[2]["id"].to_i).to eq(item_3.id)
+  end
 end


### PR DESCRIPTION
This PR:

- Adds routes for Merchant relationship endpoints
- Adds relationship associations between Merchant, Invoice and ItemSerializers
- Adds Items/InvoicesControllers under Api::V1::Merchants
- Adds specs for new relationship endpoints