### PR TITLE
Invoice Search

### DIFF
--- a/app/controllers/api/v1/invoices/search_controller.rb
+++ b/app/controllers/api/v1/invoices/search_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::Invoices::SearchController < ApplicationController
+  def index
+    render json: InvoiceSerializer.new(Invoice.search_all_by(search_params))
+  end
+
+  def show
+    if search_params.empty?
+      render json: InvoiceSerializer.new(Invoice.find_random)
+    else
+      render json: InvoiceSerializer.new(Invoice.search_by(search_params))
+    end
+  end
+
+  private
+
+  def search_params
+    params.permit(:id, :customer_id, :merchant_id, :status, :created_at, :updated_at)
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -8,6 +8,21 @@ class Invoice < ApplicationRecord
 
   validates_presence_of :status
 
+  default_scope { order(id: :asc) }
+
+  def self.search_by(search_params)
+    where(search_params).first
+  end
+
+  def self.find_random
+    order("RANDOM()")
+    .limit(1)
+  end
+
+  def self.search_all_by(search_params)
+    where(search_params)
+  end
+
   def self.paid_invoice_ids
     joins(:transactions)
     .where(transactions: {result: "success"})

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,10 +1,6 @@
 class InvoiceSerializer
   include FastJsonapi::ObjectSerializer
 
-  belongs_to :merchant
-
-  has_many :items
-
   attributes :id,
              :status,
              :customer_id,

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,8 +1,6 @@
 class ItemSerializer
   include FastJsonapi::ObjectSerializer
 
-  belongs_to :merchant
-
   attributes :id,
              :name,
              :unit_price,

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,9 +1,6 @@
 class MerchantSerializer
   include FastJsonapi::ObjectSerializer
 
-  has_many :items
-  has_many :invoices
-
   attributes :id,
              :name
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       end
 
       namespace :invoices do
+        get "/find", to: "search#show"
+        get "/random", to: "search#show"
+        get "/find_all", to: "search#index"
+        
         get "/:id/items", to: "items#index"
         get "/:id/customer", to: "customers#show"
         get "/:id/merchant", to: "merchants#show"
@@ -28,7 +32,7 @@ Rails.application.routes.draw do
         get "/find", to: "search#show"
         get "/random", to: "search#show"
         get "/find_all", to: "search#index"
-        
+
         get "/:id/invoices", to: "invoices#index"
         get "/:id/transactions", to: "transactions#index"
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -14,6 +14,59 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe "instance methods" do
+    it ".search_by" do
+      merchant_1 = create(:merchant)
+      merchant_2 = create(:merchant)
+
+      customer_1 = create(:customer)
+      customer_2 = create(:customer)
+
+      invoice_1 = create(:invoice, customer: customer_1, merchant: merchant_1, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
+      invoice_2 = create(:invoice, customer: customer_2, merchant: merchant_2, created_at: "2012-03-22T14:54:05.000Z", updated_at: "2012-03-26T14:54:05.000Z")
+
+      expect(Invoice.search_by({"id"=>"#{invoice_1.id}"})).to eq(invoice_1)
+      expect(Invoice.search_by({"id"=>"#{invoice_2.id}"})).to eq(invoice_2)
+
+      expect(Invoice.search_by({"customer_id"=>"#{invoice_1.customer_id}"})).to eq(invoice_1)
+      expect(Invoice.search_by({"customer_id"=>"#{invoice_2.customer_id}"})).to eq(invoice_2)
+
+      expect(Invoice.search_by({"merchant_id"=>"#{invoice_1.merchant_id}"})).to eq(invoice_1)
+      expect(Invoice.search_by({"merchant_id"=>"#{invoice_2.merchant_id}"})).to eq(invoice_2)
+
+      expect(Invoice.search_by({"status"=>"#{invoice_1.status}"})).to eq(invoice_1)
+
+      expect(Invoice.search_by({"created_at"=>"#{invoice_1.created_at}"})).to eq(invoice_1)
+      expect(Invoice.search_by({"created_at"=>"#{invoice_2.created_at}"})).to eq(invoice_2)
+
+      expect(Invoice.search_by({"updated_at"=>"#{invoice_1.updated_at}"})).to eq(invoice_1)
+      expect(Invoice.search_by({"updated_at"=>"#{invoice_2.updated_at}"})).to eq(invoice_2)
+    end
+
+    it ".search_all_by" do
+      merchant_1 = create(:merchant)
+      customer_1 = create(:customer)
+
+      invoice_1 = create(:invoice, customer: customer_1, merchant: merchant_1, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
+      invoice_2 = create(:invoice, customer: customer_1, merchant: merchant_1, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
+
+      expect(Invoice.search_all_by({"id"=>"#{invoice_1.id}"})).to eq([invoice_1])
+      expect(Invoice.search_all_by({"id"=>"#{invoice_2.id}"})).to eq([invoice_2])
+
+      expect(Invoice.search_all_by({"customer_id"=>"#{invoice_1.customer_id}"})).to eq([invoice_1, invoice_2])
+      expect(Invoice.search_all_by({"merchant_id"=>"#{invoice_1.merchant_id}"})).to eq([invoice_1, invoice_2])
+      expect(Invoice.search_all_by({"status"=>"#{invoice_1.status}"})).to eq([invoice_1, invoice_2])
+      expect(Invoice.search_all_by({"created_at"=>"#{invoice_1.created_at}"})).to eq([invoice_1, invoice_2])
+      expect(Invoice.search_all_by({"updated_at"=>"#{invoice_1.updated_at}"})).to eq([invoice_1, invoice_2])
+    end
+
+    it ".find_random" do
+      create_list(:invoice, 4)
+
+      ids = Invoice.pluck(:id)
+
+      expect(ids).to include(Invoice.find_random.take.id.to_i)
+    end
+
     it "#paid_invoice_ids" do
       invoice_1 = create(:invoice)
       invoice_2 = create(:invoice)
@@ -26,7 +79,7 @@ RSpec.describe Invoice, type: :model do
 
       create(:transaction, invoice: invoice_1)
       create(:transaction, invoice: invoice_2)
-      
+
       create(:failed_transaction, invoice: invoice_3)
       create(:failed_transaction, invoice: invoice_4)
       create(:failed_transaction, invoice: invoice_5)

--- a/spec/requests/api/v1/customers_request_spec.rb
+++ b/spec/requests/api/v1/customers_request_spec.rb
@@ -225,29 +225,11 @@ RSpec.describe "Customers API" do
 
     expect(customer[0]["id"].to_i).to eq(customer_1.id)
     expect(customer[1]["id"].to_i).to eq(customer_2.id)
-
-    get "/api/v1/customers/find_all?first_name=#{customer_1.first_name}"
-
-    expect(response).to be_successful
-
-    customer = JSON.parse(response.body)["data"]
-
-    expect(customer[0]["id"].to_i).to eq(customer_1.id)
-    expect(customer[1]["id"].to_i).to eq(customer_2.id)
   end
 
   it "finds all Customers by last_name" do
     customer_1 = create(:customer, last_name: "First Name 1")
     customer_2 = create(:customer, last_name: "First Name 1")
-
-    get "/api/v1/customers/find_all?last_name=#{customer_1.last_name}"
-
-    expect(response).to be_successful
-
-    customer = JSON.parse(response.body)["data"]
-
-    expect(customer[0]["id"].to_i).to eq(customer_1.id)
-    expect(customer[1]["id"].to_i).to eq(customer_2.id)
 
     get "/api/v1/customers/find_all?last_name=#{customer_1.last_name}"
 
@@ -271,29 +253,11 @@ RSpec.describe "Customers API" do
 
     expect(customer[0]["id"].to_i).to eq(customer_1.id)
     expect(customer[1]["id"].to_i).to eq(customer_2.id)
-
-    get "/api/v1/customers/find_all?created_at=#{customer_1.created_at}"
-
-    expect(response).to be_successful
-
-    customer = JSON.parse(response.body)["data"]
-
-    expect(customer[0]["id"].to_i).to eq(customer_1.id)
-    expect(customer[1]["id"].to_i).to eq(customer_2.id)
   end
 
   it "finds all Customers by updated_at" do
     customer_1 = create(:customer, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
     customer_2 = create(:customer, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
-
-    get "/api/v1/customers/find_all?created_at=#{customer_1.created_at}"
-
-    expect(response).to be_successful
-
-    customer = JSON.parse(response.body)["data"]
-
-    expect(customer[0]["id"].to_i).to eq(customer_1.id)
-    expect(customer[1]["id"].to_i).to eq(customer_2.id)
 
     get "/api/v1/customers/find_all?created_at=#{customer_1.created_at}"
 

--- a/spec/requests/api/v1/invoices_request_spec.rb
+++ b/spec/requests/api/v1/invoices_request_spec.rb
@@ -126,4 +126,244 @@ RSpec.describe "Invoices API" do
 
     expect(invoice_merchant["id"].to_i).to eq(merchant.id)
   end
+
+  it "finds a random Invoice" do
+    create_list(:invoice, 4)
+
+    ids = Invoice.pluck(:id)
+
+    get "/api/v1/invoices/random"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(ids).to include(invoice[0]["id"].to_i)
+
+    get "/api/v1/invoices/random"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(ids).to include(invoice[0]["id"].to_i)
+  end
+
+  it "finds a single Invoice by ID" do
+    invoice_1 = create(:invoice)
+    invoice_2 = create(:invoice)
+
+    get "/api/v1/invoices/find?id=#{invoice_1.id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_1.id)
+
+    get "/api/v1/invoices/find?id=#{invoice_2.id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds a single Invoice by customer_id" do
+    customer_1 = create(:customer)
+    customer_2 = create(:customer)
+
+    invoice_1 = create(:invoice, customer: customer_1)
+    invoice_2 = create(:invoice, customer: customer_2)
+
+    get "/api/v1/invoices/find?customer_id=#{invoice_1.customer_id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_1.id)
+
+    get "/api/v1/invoices/find?customer_id=#{invoice_2.customer_id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds a single Invoice by merchant_id" do
+    merchant_1 = create(:merchant)
+    merchant_2 = create(:merchant)
+
+    invoice_1 = create(:invoice, merchant: merchant_1)
+    invoice_2 = create(:invoice, merchant: merchant_2)
+
+    get "/api/v1/invoices/find?merchant_id=#{invoice_1.merchant_id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_1.id)
+
+    get "/api/v1/invoices/find?merchant_id=#{invoice_2.merchant_id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds a single Invoice by status" do
+    invoice_1 = create(:invoice)
+
+    get "/api/v1/invoices/find?status=#{invoice_1.status}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_1.id)
+  end
+
+  it "finds a single Invoice by created_at" do
+    invoice_1 = create(:invoice, created_at: "2012-03-20T14:54:05.000Z")
+    invoice_2 = create(:invoice, created_at: "2012-03-22T14:54:05.000Z")
+
+    get "/api/v1/invoices/find?created_at=#{invoice_1.created_at}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]["attributes"]
+
+    expect(invoice["id"].to_i).to eq(invoice_1.id)
+
+    get "/api/v1/invoices/find?created_at=#{invoice_2.created_at}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds a single Invoice by updated_at" do
+    invoice_1 = create(:invoice, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
+    invoice_2 = create(:invoice, created_at: "2012-03-22T14:54:05.000Z", updated_at: "2012-03-26T14:54:05.000Z")
+
+    get "/api/v1/invoices/find?updated_at=#{invoice_1.updated_at}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_1.id)
+
+    get "/api/v1/invoices/find?updated_at=#{invoice_2.updated_at}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds all Invoices by ID" do
+    invoice_1 = create(:invoice)
+    invoice_2 = create(:invoice)
+
+    get "/api/v1/invoices/find_all?id=#{invoice_1.id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice[0]["id"].to_i).to eq(invoice_1.id)
+
+    get "/api/v1/invoices/find_all?id=#{invoice_2.id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice[0]["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds all Invoices by customer_id" do
+    customer = create(:customer)
+
+    invoice_1 = create(:invoice, customer: customer)
+    invoice_2 = create(:invoice, customer: customer)
+
+    get "/api/v1/invoices/find_all?customer_id=#{invoice_1.customer_id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice[0]["id"].to_i).to eq(invoice_1.id)
+    expect(invoice[1]["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds all Invoices by merchant_id" do
+    merchant = create(:merchant)
+
+    invoice_1 = create(:invoice, merchant: merchant)
+    invoice_2 = create(:invoice, merchant: merchant)
+
+    get "/api/v1/invoices/find_all?merchant_id=#{invoice_1.merchant_id}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice[0]["id"].to_i).to eq(invoice_1.id)
+    expect(invoice[1]["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds all Invoices by status" do
+    invoice_1 = create(:invoice)
+    invoice_2 = create(:invoice)
+
+    get "/api/v1/invoices/find_all?status=#{invoice_1.status}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice[0]["id"].to_i).to eq(invoice_1.id)
+    expect(invoice[1]["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds all Invoices by created_at" do
+    invoice_1 = create(:invoice, created_at: "2012-03-20T14:54:05.000Z")
+    invoice_2 = create(:invoice, created_at: "2012-03-20T14:54:05.000Z")
+
+    get "/api/v1/invoices/find_all?created_at=#{invoice_1.created_at}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice[0]["id"].to_i).to eq(invoice_1.id)
+    expect(invoice[1]["id"].to_i).to eq(invoice_2.id)
+  end
+
+  it "finds all Invoices by updated_at" do
+    invoice_1 = create(:invoice, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
+    invoice_2 = create(:invoice, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
+
+    get "/api/v1/invoices/find_all?created_at=#{invoice_1.created_at}"
+
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(invoice[0]["id"].to_i).to eq(invoice_1.id)
+    expect(invoice[1]["id"].to_i).to eq(invoice_2.id)
+  end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -200,15 +200,6 @@ RSpec.describe "Merchants API" do
 
     expect(merchant[0]["id"].to_i).to eq(merchant_1.id)
     expect(merchant[1]["id"].to_i).to eq(merchant_2.id)
-
-    get "/api/v1/merchants/find_all?name=#{merchant_1.name}"
-
-    expect(response).to be_successful
-
-    merchant = JSON.parse(response.body)["data"]
-
-    expect(merchant[0]["id"].to_i).to eq(merchant_1.id)
-    expect(merchant[1]["id"].to_i).to eq(merchant_2.id)
   end
 
   it "finds all Merchants by created_at" do
@@ -223,29 +214,11 @@ RSpec.describe "Merchants API" do
 
     expect(merchant[0]["id"].to_i).to eq(merchant_1.id)
     expect(merchant[1]["id"].to_i).to eq(merchant_2.id)
-
-    get "/api/v1/merchants/find_all?created_at=#{merchant_1.created_at}"
-
-    expect(response).to be_successful
-
-    merchant = JSON.parse(response.body)["data"]
-
-    expect(merchant[0]["id"].to_i).to eq(merchant_1.id)
-    expect(merchant[1]["id"].to_i).to eq(merchant_2.id)
   end
 
   it "finds all Merchants by updated_at" do
     merchant_1 = create(:merchant, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
     merchant_2 = create(:merchant, created_at: "2012-03-20T14:54:05.000Z", updated_at: "2012-03-28T14:54:05.000Z")
-
-    get "/api/v1/merchants/find_all?created_at=#{merchant_1.created_at}"
-
-    expect(response).to be_successful
-
-    merchant = JSON.parse(response.body)["data"]
-
-    expect(merchant[0]["id"].to_i).to eq(merchant_1.id)
-    expect(merchant[1]["id"].to_i).to eq(merchant_2.id)
 
     get "/api/v1/merchants/find_all?created_at=#{merchant_1.created_at}"
 


### PR DESCRIPTION
This PR:

- Removes relationship identifiers from serializers
- Removes repetition from Customer/Merchant API request specs
- Adds routes for Invoice record search endpoints
- Adds search_by, search_all_by and find_random class methods and specs for Invoice model
- Adds specs for Invoice record search endpoints